### PR TITLE
Fixed input json "parameters" handling

### DIFF
--- a/front/js/app/dom_manager.js
+++ b/front/js/app/dom_manager.js
@@ -36,7 +36,7 @@ function generateHTMLCodeForClassesAndParameters(dom, phrase, acceptMode=false) 
     parameters.push("</div>");
     classes = classes.join("");
 
-    if (jsonResponse.parameters !== null) {
+    if (jsonResponse.parameters != null) {
         let dropdownMenusCount = 0;
         let inputGroupsCount = 0;
 
@@ -98,8 +98,8 @@ function generateHTMLCodeForClassesAndParameters(dom, phrase, acceptMode=false) 
             }
         });
         parameters.push("</form>");
-        parameters = parameters.join("");
     }
+    parameters = parameters.join("");
 
     html.push(classes);
     html.push(parameters);


### PR DESCRIPTION
- If the "parameters" key is not present in the input json file, jsonResponse.parameters is equal to undefined, not null. Abstract equality comparison should be used instead of strict.
- Joining of parameters tokens should be done in all cases, even if "parameters" key is not present or if it's null. Otherwise the tokens are joined with "," which breaks the program logic.